### PR TITLE
fix repo file name for AlmaLinux >=8.5

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -29,8 +29,24 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - image: "enterpriselinux"
+          - namespace: robertdebock
+            image: "enterpriselinux"
             tag: "8"
+          - namespace: robertdebock
+            image: "enterpriselinux"
+            tag: "9"
+          - namespace: library
+            image: "rockylinux"
+            tag: "8"
+          - namespace: library
+            image: "rockylinux"
+            tag: "9"
+          - namespace: library
+            image: "almalinux"
+            tag: "8"
+          - namespace: library
+            image: "almalinux"
+            tag: "9"
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -43,5 +59,6 @@ jobs:
       - name: molecule
         uses: robertdebock/molecule-action@5.0.2
         with:
+          namespace: ${{ matrix.config.namespace }}
           image: ${{ matrix.config.image }}
           tag: ${{ matrix.config.tag }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,8 +12,24 @@ molecule:
     - if: $CI_COMMIT_REF_NAME == "master"
   parallel:
     matrix:
-      - image: "enterpriselinux"
+      - namespace: robertdebock
+        image: "enterpriselinux"
         tag: "8"
+      - namespace: robertdebock
+        image: "enterpriselinux"
+        tag: "9"
+      - namespace: library
+        image: "rockylinux"
+        tag: "8"
+      - namespace: library
+        image: "rockylinux"
+        tag: "9"
+      - namespace: library
+        image: "almalinux"
+        tag: "8"
+      - namespace: library
+        image: "almalinux"
+        tag: "9"
 
 galaxy:
   script:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # tasks file for powertools
 
-- name: Enable powertools
+- name: "Enable PowerTools repo '{{ powertools_repo_name }}' in '{{ powertools_repo_file }}'"
   community.general.ini_file:
     path: "/etc/yum.repos.d/{{ powertools_repo_file }}"
     section: "{{ powertools_repo_name }}"
@@ -10,6 +10,5 @@
     mode: "0644"
   notify:
     - Yum update cache
-  when:
-    - ansible_distribution in [ "CentOS", "EL", "Rocky", "AlmaLinux" ]
-    - ansible_distribution_major_version >= "8"
+  when: powertools_repo_enabled
+

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,21 +1,33 @@
 ---
 # vars file for powertools
 
+# NOTE: It could have been easier if we could check if 'X sorts after Y'
+# and just take the first Y that sorts after the current OS version
+_powertools_os_keys_internal:
+  - "{{ [[ansible_distribution, ansible_distribution_major_version]|join('_')]|
+        product(range(1, ((ansible_distribution_version|split('.'))[1]|int + 1)))|
+        map('join', '_')|
+        reverse }}"
+  - "{{ [ ansible_distribution, ansible_distribution_major_version ] | join('_') }}"
+  - "{{ ansible_distribution }}"
+  - "{{ ansible_os_family }}"
+_powertools_os_keys: "{{ _powertools_os_keys_internal|flatten }}"
+
 _powertools_repo_name:
   RedHat: powertools
   AlmaLinux_9: crb
 
-powertools_repo_name: "{{ _powertools_repo_name[ansible_distribution ~ '_' ~ ansible_distribution_major_version] | default(
-                          _powertools_repo_name[ansible_distribution] ) | default(
-                          _powertools_repo_name[ansible_os_family] ) }}"
+powertools_repo_name: "{{ _powertools_os_keys|map('extract', _powertools_repo_name)|select('defined')|first }}"
 
 _powertools_repo_file:
   RedHat: "{{ ansible_distribution }}-PowerTools.repo"
   Rocky: "{{ ansible_distribution }}-PowerTools.repo"
   AlmaLinux_8: "almalinux-PowerTools.repo"
+  AlmaLinux_8_5: "almalinux-powertools.repo"
   AlmaLinux_9: "almalinux-crb.repo"
   CentOS: "{{ ansible_distribution }}-{{ ansible_distribution_release }}-PowerTools.repo"
 
-powertools_repo_file: "{{ _powertools_repo_file[ansible_distribution ~ '_' ~ ansible_distribution_major_version] | default(
-                          _powertools_repo_file[ansible_distribution] ) | default(
-                          _powertools_repo_file[ansible_os_family] ) }}"
+powertools_repo_file: "{{ _powertools_os_keys|map('extract', _powertools_repo_file)|select('defined')|first }}"
+
+powertools_repo_enabled: '{{ (ansible_distribution in [ "CentOS", "EL", "Rocky", "AlmaLinux" ]) and
+                             (ansible_distribution_major_version|int >= 8) }}'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -16,13 +16,17 @@ _powertools_os_keys: "{{ _powertools_os_keys_internal|flatten }}"
 _powertools_repo_name:
   RedHat: powertools
   AlmaLinux_9: crb
+  Rocky_9: crb
 
 powertools_repo_name: "{{ _powertools_os_keys|map('extract', _powertools_repo_name)|select('defined')|first }}"
 
 _powertools_repo_file:
   RedHat: "{{ ansible_distribution }}-PowerTools.repo"
   Rocky: "{{ ansible_distribution }}-PowerTools.repo"
+  # Rocky >=9.0
+  Rocky_9: "{{ ansible_distribution|lower }}.repo"
   AlmaLinux_8: "almalinux-PowerTools.repo"
+  # Alma >=8.5
   AlmaLinux_8_5: "almalinux-powertools.repo"
   AlmaLinux_9: "almalinux-crb.repo"
   CentOS: "{{ ansible_distribution }}-{{ ansible_distribution_release }}-PowerTools.repo"


### PR DESCRIPTION
Starting from AlmaLinux 8.5, the repository filename is called `almalinux-powertools.repo` instead of `almalinux-PowerTools.repo`.

This change should fix that.